### PR TITLE
feat: musical synthesis palette for course mode

### DIFF
--- a/src/only4bms/game/course_generator.py
+++ b/src/only4bms/game/course_generator.py
@@ -56,19 +56,23 @@ def generate_random_course(duration_ms, out_path, template_dir, difficulty="BEGI
     if not os.path.exists(os.path.dirname(out_path)):
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
 
-    # Force regeneration of key_tap if we want to hear the new sound
+    # Force regeneration of all procedural WAV assets so volume changes take effect
+    for wav_name in ("key_tap.wav", "kick_soft.wav", "snare_soft.wav", "hat_soft.wav"):
+        wav_path = os.path.join(template_dir, wav_name)
+        if os.path.exists(wav_path):
+            try: os.remove(wav_path)
+            except: pass
     tap_path = os.path.join(template_dir, "key_tap.wav")
-    if os.path.exists(tap_path):
-        try: os.remove(tap_path)
-        except: pass
 
     # Generate procedural WAV assets if they don't exist
-    _generate_wav(os.path.join(template_dir, "kick_soft.wav"), 80, 0.5, 'kick', volume=0.4)
-    _generate_wav(os.path.join(template_dir, "snare_soft.wav"), 400, 0.3, 'noise', volume=0.15)
-    _generate_wav(os.path.join(template_dir, "hat_soft.wav"), 800, 0.1, 'noise', volume=0.08)
-    
-    # Improved keyboard-like clack (sharper attack, lower volume)
-    _generate_wav(tap_path, 2500, 0.05, 'clack', volume=0.12)
+    # Volume levels match typical BMS WAV files (~1.0 peak) so that
+    # the in-game volume slider controls perceived loudness correctly.
+    _generate_wav(os.path.join(template_dir, "kick_soft.wav"), 80, 0.5, 'kick', volume=0.9)
+    _generate_wav(os.path.join(template_dir, "snare_soft.wav"), 400, 0.3, 'noise', volume=0.7)
+    _generate_wav(os.path.join(template_dir, "hat_soft.wav"), 800, 0.1, 'noise', volume=0.5)
+
+    # Keyboard-like clack for key tap feedback
+    _generate_wav(tap_path, 2500, 0.05, 'clack', volume=0.8)
 
     has_ln = False
     has_sv = False

--- a/src/only4bms/game/course_generator.py
+++ b/src/only4bms/game/course_generator.py
@@ -5,45 +5,192 @@ import numpy as np
 
 import only4bms.i18n as i18n
 
+# ── A minor pentatonic frequencies across octaves ──────────────────────────
+# A, C, D, E, G
+_PENTA = {
+    1: [55.0, 65.41, 73.42, 82.41, 98.0],
+    2: [110.0, 130.81, 146.83, 164.81, 196.0],
+    3: [220.0, 261.63, 293.66, 329.63, 392.0],
+    4: [440.0, 523.25, 587.33, 659.25, 784.0],
+}
+
+# ── Master sound table ─────────────────────────────────────────────────────
+# (wav_id, filename, freq, duration, wave_type, volume)
+_SOUND_TABLE = [
+    # BGM percussion
+    ("01", "kick.wav",       80,    0.5,  'kick',       0.9),
+    ("02", "snare.wav",      400,   0.3,  'noise',      0.7),
+    ("03", "hat_closed.wav", 800,   0.1,  'noise',      0.5),
+    ("04", "hat_open.wav",   6000,  0.25, 'hihat_open', 0.5),
+    # Sub bass (octave 1)
+    *[("%02X" % (0x10 + i), f"bass_{i}.wav", _PENTA[1][i], 0.8, 'sub_bass', 0.85) for i in range(5)],
+    # Bass pluck (octave 2)
+    *[("%02X" % (0x15 + i), f"bpluck_{i}.wav", _PENTA[2][i], 0.2, 'pluck', 0.7) for i in range(5)],
+    # Lead low (octave 3)
+    *[("1%s" % chr(65 + i), f"lead_lo_{i}.wav", _PENTA[3][i], 0.25, 'synth_lead', 0.65) for i in range(5)],
+    # Lead high (octave 4)
+    *[("1%s" % chr(70 + i), f"lead_hi_{i}.wav", _PENTA[4][i], 0.25, 'synth_lead', 0.65) for i in range(5)],
+    # Arp pluck (octave 4)
+    *[("%02X" % (0x20 + i), f"arp_{i}.wav", _PENTA[4][i], 0.15, 'pluck', 0.7) for i in range(5)],
+    # Chord stab (octave 3)
+    *[("%02X" % (0x25 + i), f"chord_{i}.wav", _PENTA[3][i], 0.2, 'chord_stab', 0.6) for i in range(5)],
+    # FX
+    ("2A", "fx_riser_lo.wav",  400, 0.3, 'fx_riser',  0.5),
+    ("2B", "fx_riser_hi.wav",  600, 0.3, 'fx_riser',  0.5),
+    ("2C", "fx_impact_lo.wav", 80,  0.2, 'fx_impact', 0.7),
+    ("2D", "fx_impact_hi.wav", 120, 0.2, 'fx_impact', 0.7),
+]
+
+
+def _build_sound_palette():
+    """Return categorized WAV ID groups for note assignment."""
+    return {
+        'bass':       ["%02X" % (0x10 + i) for i in range(5)],
+        'bass_pluck': ["%02X" % (0x15 + i) for i in range(5)],
+        'lead_lo':    ["1%s" % chr(65 + i) for i in range(5)],
+        'lead_hi':    ["1%s" % chr(70 + i) for i in range(5)],
+        'arp':        ["%02X" % (0x20 + i) for i in range(5)],
+        'chord':      ["%02X" % (0x25 + i) for i in range(5)],
+        'fx_riser':   ["2A", "2B"],
+        'fx_impact':  ["2C", "2D"],
+        'hat_open':   ["04"],
+    }
+
+
+def _pick_note_sound(palette, lane_idx, step, measure_num, phrase):
+    """Pick a WAV ID based on lane, beat position, and musical phrase state."""
+    root = phrase['root_idx']
+    style = phrase['style']
+    pitch_idx = (root + step // 4) % 5
+
+    if lane_idx == 0:  # Bass register
+        if step % 8 == 0:
+            return palette['bass'][pitch_idx]
+        return palette['bass_pluck'][pitch_idx]
+
+    elif lane_idx == 1:  # Mid-low: lead / chord
+        if step % 4 == 0 and (style == 'future_bass' or random.random() < 0.4):
+            return palette['chord'][pitch_idx]
+        return palette['lead_lo'][(pitch_idx + 1) % 5]
+
+    elif lane_idx == 2:  # Mid-high: lead / arp
+        if style == 'arp' or step % 2 == 0:
+            arp_idx = (pitch_idx + step // 2) % 5
+            return palette['arp'][arp_idx]
+        return palette['lead_hi'][pitch_idx]
+
+    else:  # lane 3: High / FX
+        if step == 0 and random.random() < 0.15:
+            return random.choice(palette['fx_impact'])
+        if step % 2 != 0:
+            return palette['arp'][(pitch_idx + 2) % 5]
+        return palette['lead_hi'][(pitch_idx + 3) % 5]
+
+
+def _ns(palette, lane, lanes, step, m, phrase):
+    """Shorthand: resolve lane string to index and pick note sound."""
+    return _pick_note_sound(palette, lanes.index(lane), step, m, phrase)
+
+
 def _generate_wav(filename, freq, duration_sec, wave_type='sine', samplerate=44100, volume=0.5):
     if os.path.exists(filename):
         return
-        
+
     t = np.linspace(0, duration_sec, int(samplerate * duration_sec), endpoint=False)
-    
+
     if wave_type == 'sine':
         audio = np.sin(2 * np.pi * freq * t)
     elif wave_type == 'square':
         audio = np.sign(np.sin(2 * np.pi * freq * t))
     elif wave_type == 'kick':
-        freq_env = np.exp(-t * 30) * freq 
+        freq_env = np.exp(-t * 30) * freq
         audio = np.sin(2 * np.pi * freq_env * t)
     elif wave_type == 'noise':
         audio = np.random.uniform(-1, 1, len(t))
     elif wave_type == 'clack':
-        # Mix of high-pitched short pulse and noise for a keyboard "clack"
         noise = np.random.uniform(-1, 1, len(t)) * 0.5
         pulse = np.sin(2 * np.pi * freq * t) * 0.5
         audio = noise + pulse
+    elif wave_type == 'sub_bass':
+        # Saw-based bass with harmonics — blends with synth_lead/pluck palette
+        saw = 2.0 * ((t * freq) % 1.0) - 1.0
+        saw2 = 2.0 * ((t * freq * 2.005) % 1.0) - 1.0  # octave up, slight detune
+        audio = saw * 0.6 + saw2 * 0.3
+        # Soft clip for warmth (tanh distortion)
+        audio = np.tanh(audio * 2.0) * 0.7
+    elif wave_type == 'synth_lead':
+        # Detuned supersaw: 3 slightly detuned sawtooth waves
+        saw1 = 2.0 * ((t * freq) % 1.0) - 1.0
+        saw2 = 2.0 * ((t * freq * 1.005) % 1.0) - 1.0
+        saw3 = 2.0 * ((t * freq * 0.995) % 1.0) - 1.0
+        audio = (saw1 + saw2 + saw3) / 3.0
+    elif wave_type == 'pluck':
+        # Short pluck: sine + 2nd harmonic, fast decay
+        audio = np.sin(2 * np.pi * freq * t) + 0.3 * np.sin(4 * np.pi * freq * t)
+    elif wave_type == 'chord_stab':
+        # Root + major 3rd + 5th
+        audio = (np.sin(2 * np.pi * freq * t) +
+                 np.sin(2 * np.pi * freq * 1.26 * t) +
+                 np.sin(2 * np.pi * freq * 1.5 * t)) / 3.0
+    elif wave_type == 'fx_riser':
+        # Frequency sweep upward
+        sweep = np.linspace(freq, freq * 4, len(t))
+        audio = np.sin(2 * np.pi * np.cumsum(sweep) / samplerate)
+    elif wave_type == 'fx_impact':
+        # Noise burst + low sine
+        audio = np.random.uniform(-1, 1, len(t)) * 0.6 + np.sin(2 * np.pi * freq * t) * 0.4
+    elif wave_type == 'hihat_open':
+        # Longer noise with bandpass-like shaping
+        audio = np.random.uniform(-1, 1, len(t))
+        # Simple highpass: subtract smoothed version
+        kernel_size = max(1, int(samplerate * 0.001))
+        if kernel_size > 1:
+            smooth = np.convolve(audio, np.ones(kernel_size) / kernel_size, mode='same')
+            audio = audio - smooth * 0.5
     else:
         audio = np.sin(2 * np.pi * freq * t)
 
-    if wave_type in ('kick', 'clack'):
-        envelope = np.exp(-t * (30 if wave_type == 'kick' else 80))
+    # Envelopes per wave type
+    if wave_type == 'kick':
+        envelope = np.exp(-t * 30)
+    elif wave_type == 'clack':
+        envelope = np.exp(-t * 80)
     elif wave_type == 'noise':
         envelope = np.exp(-t * 20)
+    elif wave_type == 'sub_bass':
+        # Slower decay for sustained bass body
+        attack = np.minimum(t / 0.005, 1.0)
+        envelope = attack * np.exp(-t * 2.5)
+    elif wave_type == 'synth_lead':
+        # ADSR-like: fast attack, decay to sustain, then release
+        attack = np.minimum(t / 0.01, 1.0)
+        release = np.exp(-np.maximum(t - 0.15, 0) * 6)
+        envelope = attack * release
+    elif wave_type == 'pluck':
+        envelope = np.exp(-t * 15)
+    elif wave_type == 'chord_stab':
+        envelope = np.exp(-t * 8)
+    elif wave_type == 'fx_riser':
+        # Ramp up then sharp cut
+        envelope = np.minimum(t / (duration_sec * 0.8), 1.0)
+    elif wave_type == 'fx_impact':
+        envelope = np.exp(-t * 25)
+    elif wave_type == 'hihat_open':
+        envelope = np.exp(-t * 6)
     else:
-        # Synth envelope
         envelope = np.exp(-t * 3)
-        
+
     audio = audio * envelope * volume
+    # Clip to prevent overflow before int16 conversion
+    audio = np.clip(audio, -1.0, 1.0)
     audio = np.int16(audio * 32767)
-    
+
     with wave.open(filename, 'w') as w:
         w.setnchannels(1)
         w.setsampwidth(2)
         w.setframerate(samplerate)
         w.writeframes(audio.tobytes())
+
 
 def generate_random_course(duration_ms, out_path, template_dir, difficulty="BEGINNER"):
     """
@@ -56,23 +203,23 @@ def generate_random_course(duration_ms, out_path, template_dir, difficulty="BEGI
     if not os.path.exists(os.path.dirname(out_path)):
         os.makedirs(os.path.dirname(out_path), exist_ok=True)
 
-    # Force regeneration of all procedural WAV assets so volume changes take effect
-    for wav_name in ("key_tap.wav", "kick_soft.wav", "snare_soft.wav", "hat_soft.wav"):
-        wav_path = os.path.join(template_dir, wav_name)
+    # Force regeneration of all procedural WAV assets
+    for entry in _SOUND_TABLE:
+        wav_path = os.path.join(template_dir, entry[1])
         if os.path.exists(wav_path):
             try: os.remove(wav_path)
             except: pass
-    tap_path = os.path.join(template_dir, "key_tap.wav")
 
-    # Generate procedural WAV assets if they don't exist
-    # Volume levels match typical BMS WAV files (~1.0 peak) so that
-    # the in-game volume slider controls perceived loudness correctly.
-    _generate_wav(os.path.join(template_dir, "kick_soft.wav"), 80, 0.5, 'kick', volume=0.9)
-    _generate_wav(os.path.join(template_dir, "snare_soft.wav"), 400, 0.3, 'noise', volume=0.7)
-    _generate_wav(os.path.join(template_dir, "hat_soft.wav"), 800, 0.1, 'noise', volume=0.5)
+    # Generate all WAV assets
+    for wav_id, fname, freq, dur, wtype, vol in _SOUND_TABLE:
+        _generate_wav(os.path.join(template_dir, fname), freq, dur, wtype, volume=vol)
 
-    # Keyboard-like clack for key tap feedback
-    _generate_wav(tap_path, 2500, 0.05, 'clack', volume=0.8)
+    # Sound palette and phrase state
+    palette = _build_sound_palette()
+    phrase = {
+        'root_idx': 0,
+        'style': random.choice(['trap', 'future_bass', 'arp']),
+    }
 
     has_ln = False
     has_sv = False
@@ -101,7 +248,7 @@ def generate_random_course(duration_ms, out_path, template_dir, difficulty="BEGI
         # Fallback for any unknown difficulty
         bpm = 150
         desc_str = i18n.get("gen_custom_trial").format(bpm=bpm)
-        
+
     if has_ln: desc_str += i18n.get("gen_ln")
     if has_sv: desc_str += i18n.get("gen_sv")
 
@@ -130,47 +277,66 @@ def generate_random_course(duration_ms, out_path, template_dir, difficulty="BEGI
 #BPM28 {bpm * 1.15:.2f}
 #PLAYLEVEL {'1' if difficulty=='BEGINNER' else '5' if difficulty=='INTERMEDIATE' else '10'}
 """
-    wavs = [
-        ("01", "kick_soft.wav"),
-        ("02", "snare_soft.wav"),
-        ("03", "hat_soft.wav"),
-        ("10", "key_tap.wav"),
-    ]
-    
-    for wid, wname in wavs:
-        header += f"#WAV{wid} {wname}\n"
+    for wav_id, fname, *_ in _SOUND_TABLE:
+        header += f"#WAV{wav_id} {fname}\n"
     header += "\n"
 
     ms_per_measure = (240.0 / bpm) * 1000.0
     num_measures = int(duration_ms / ms_per_measure) + 1
-    
+
     chart_data = ""
-    # Unified universal tap sound for all difficulties (cleaner audio feedback)
-    synths = ["10"]
-    lanes = ["11", "12", "13", "14"] # 4-Key bounds in standard mapping
-    ln_lanes = ["51", "52", "53", "54"] # 4-Key bounds for LN
+    lanes = ["11", "12", "13", "14"]  # 4-Key bounds in standard mapping
+    ln_lanes = ["51", "52", "53", "54"]  # 4-Key bounds for LN
 
     def get_empty_measure():
         d = {l: ["00"] * 16 for l in lanes}
         d.update({ln: ["00"] * 16 for ln in ln_lanes})
-        d["08"] = ["00"] * 16 # For BPM changes
-        d["01"] = ["00"] * 16 # For BGM kick
+        d["08"] = ["00"] * 16  # For BPM changes
+        d["01"] = ["00"] * 16  # For BGM
         return d
+
+    def ns(lane, step):
+        """Pick note sound for a lane string at a given step."""
+        return _pick_note_sound(palette, lanes.index(lane), step, m, phrase)
+
+    def ns_idx(lane_idx, step):
+        """Pick note sound for a lane index at a given step."""
+        return _pick_note_sound(palette, lane_idx, step, m, phrase)
 
     for m in range(num_measures + 2):
         measure_str = f"{m:03d}"
         m_data = get_empty_measure()
-        
+
         if m < 2:
             # 2 measures of empty space for countdown break
-            chart_data += f"#{measure_str}01:00\n" # dummy bgm tick
+            chart_data += f"#{measure_str}01:00\n"
             continue
-            
-        m_data["01"][0] = "01"
-        m_data["01"][4] = "02"
-        m_data["01"][8] = "01"
-        m_data["01"][12] = "02"
-        
+
+        # Update phrase state
+        if (m - 2) % 4 == 0:
+            phrase['root_idx'] = (phrase['root_idx'] + 2) % 5
+        if (m - 2) % 8 == 0:
+            phrase['style'] = random.choice(['trap', 'future_bass', 'arp'])
+
+        # ── BGM drum pattern ──────────────────────────────────────────
+        m_data["01"][0]  = "01"  # kick
+        m_data["01"][4]  = "02"  # snare
+        m_data["01"][8]  = "01"  # kick
+        m_data["01"][12] = "02"  # snare
+
+        # Hi-hat 8th notes on even measures
+        if m % 2 == 0:
+            for s in [2, 6, 10, 14]:
+                m_data["01"][s] = "03"
+
+        # Open hat accent every 4 measures
+        if m % 4 == 2:
+            m_data["01"][6] = "04"
+
+        # FX riser on phrase transitions
+        if m >= 2 and (m - 2) % 4 == 3:
+            m_data["01"][12] = random.choice(palette['fx_riser'])
+
         # Inject BPM variations (Ultra-Smooth transition with ±15% caps)
         if has_sv and m > 2:
             # Shift frequency by difficulty
@@ -178,74 +344,66 @@ def generate_random_course(duration_ms, out_path, template_dir, difficulty="BEGI
             if m % freq == 0:
                 is_speed_up = random.random() < 0.5
                 if is_speed_up:
-                    # Ultra-Smooth Ramp Up: 8 steps spread across the measure
                     m_data["08"][0] = "21"
                     m_data["08"][2] = "22"
                     m_data["08"][4] = "24"
                     m_data["08"][6] = "26"
-                    m_data["08"][8] = "28" # Max (1.15x)
-                    # Gentle return to normal
+                    m_data["08"][8] = "28"
                     m_data["08"][12] = "24"
                     m_data["08"][14] = "21"
                 else:
-                    # Ultra-Smooth Ramp Down: 8 steps spread across the measure
                     m_data["08"][0] = "11"
                     m_data["08"][2] = "12"
                     m_data["08"][4] = "14"
                     m_data["08"][6] = "16"
-                    m_data["08"][8] = "18" # Max (0.85x)
-                    # Gentle return to normal
+                    m_data["08"][8] = "18"
                     m_data["08"][12] = "14"
                     m_data["08"][14] = "11"
             else:
-                # Reset to normal BPM at the start of non-SV measures
-                # This must be at pos=0.0 to ensure 예고 line color resets
                 m_data["08"][0] = "00"
-        
+
+        # ── Note patterns ─────────────────────────────────────────────
         if difficulty == "BEGINNER":
-            # True Novice: 1 active lane, sparsely placed 4th notes
             active = random.choice(lanes)
             rhythm_type = random.choice(["4th", "sparse"])
             if rhythm_type == "4th":
                 for step in [0, 4, 8, 12]:
-                    m_data[active][step] = random.choice(synths)
-            else: # sparse
-                m_data[active][random.choice([0, 8])] = random.choice(synths)
+                    m_data[active][step] = ns(active, step)
+            else:
+                step = random.choice([0, 8])
+                m_data[active][step] = ns(active, step)
 
         elif difficulty == "INTERMEDIATE":
-            # Intermediate: 8th-note density, no sparse beginner patterns
             pattern_type = random.choice([
                 "chords_8th", "trill_8th", "stairs_8th",
                 "jack_8th", "combo_fill", "ln_dense", "alternating_8th"
             ])
-            # ln_dense fallback when LN not enabled
             if pattern_type == "ln_dense" and not has_ln:
                 pattern_type = "alternating_8th"
 
             if pattern_type == "ln_dense":
-                # LN holding one lane + dense 8th fill on others
                 ln_idx = random.randint(0, 3)
-                m_data[ln_lanes[ln_idx]][0]  = random.choice(synths)
-                m_data[ln_lanes[ln_idx]][14] = random.choice(synths)
+                m_data[ln_lanes[ln_idx]][0]  = ns_idx(ln_idx, 0)
+                m_data[ln_lanes[ln_idx]][14] = ns_idx(ln_idx, 14)
                 avail = [lanes[i] for i in range(4) if i != ln_idx]
                 for step in range(0, 16, 2):
                     if random.random() < 0.7:
-                        m_data[random.choice(avail)][step] = random.choice(synths)
+                        l = random.choice(avail)
+                        m_data[l][step] = ns(l, step)
 
             elif pattern_type == "chords_8th":
-                # Singles / 2-note chords every 8th note
                 for step in range(0, 16, 2):
                     chord = random.sample(lanes, random.choice([1, 1, 2]))
-                    for l in chord: m_data[l][step] = random.choice(synths)
+                    for l in chord:
+                        m_data[l][step] = ns(l, step)
 
             elif pattern_type == "trill_8th":
-                # Fast 8th-note trill between 2 lanes
                 tl = random.sample(lanes, 2)
                 for i, step in enumerate(range(0, 16, 2)):
-                    m_data[tl[i % 2]][step] = random.choice(synths)
+                    l = tl[i % 2]
+                    m_data[l][step] = ns(l, step)
 
             elif pattern_type == "stairs_8th":
-                # Non-sequential 8-step pattern — rejects 3+ consecutive ascending/descending
                 def _has_long_run(seq, run=3):
                     for i in range(len(seq) - run + 1):
                         sub = seq[i:i+run]
@@ -260,179 +418,162 @@ def generate_random_course(duration_ms, out_path, template_dir, difficulty="BEGI
                     if not _has_long_run(seq):
                         break
                 for i in range(8):
-                    m_data[lanes[seq[i]]][i * 2] = random.choice(synths)
+                    lane_idx = seq[i]
+                    step = i * 2
+                    m_data[lanes[lane_idx]][step] = ns_idx(lane_idx, step)
 
             elif pattern_type == "jack_8th":
-                # One lane plays every 8th; another lane fills occasionally
                 jack = random.choice(lanes)
                 fill = random.choice([l for l in lanes if l != jack])
                 for step in range(0, 16, 2):
-                    m_data[jack][step] = random.choice(synths)
+                    m_data[jack][step] = ns(jack, step)
                     if step % 4 == 0 and random.random() < 0.4:
-                        m_data[fill][step] = random.choice(synths)
+                        m_data[fill][step] = ns(fill, step)
 
             elif pattern_type == "combo_fill":
-                # First half: cross pattern (non-sequential), second half: chords
                 cross = random.choice([[0,2,1,3], [3,1,2,0], [1,3,0,2], [2,0,3,1]])
                 for i, step in enumerate(range(0, 8, 2)):
-                    m_data[lanes[cross[i]]][step] = random.choice(synths)
+                    m_data[lanes[cross[i]]][step] = ns_idx(cross[i], step)
                 for step in range(8, 16, 2):
                     chord = random.sample(lanes, random.choice([1, 2]))
-                    for l in chord: m_data[l][step] = random.choice(synths)
+                    for l in chord:
+                        m_data[l][step] = ns(l, step)
 
             else:  # alternating_8th
-                # Left pair / right pair alternating every 8th note
                 left  = [lanes[0], lanes[1]]
                 right = [lanes[2], lanes[3]]
                 for i, step in enumerate(range(0, 16, 2)):
                     side = left if i % 2 == 0 else right
-                    m_data[random.choice(side)][step] = random.choice(synths)
-                    if random.random() < 0.25:  # occasional double
-                        m_data[random.choice(side)][step] = random.choice(synths)
+                    l = random.choice(side)
+                    m_data[l][step] = ns(l, step)
+                    if random.random() < 0.25:
+                        l2 = random.choice(side)
+                        m_data[l2][step] = ns(l2, step)
 
-
-        else:  # ADVANCED
-            # 10 distinct pattern types, weighted away from repetition
+        else:  # ADVANCED / ORDEAL
             pattern_types = [
-                "stream_random",       # true random 16ths
-                "stream_jump",         # 16ths with chord jumps
-                "jacks",               # same-lane repeats
-                "trill_fast",          # rapid 2-lane trill
-                "complex_stairs",      # non-linear stair
-                "hand_stream",         # chord + 16th mix
-                "ln_stream",           # LN + stream
-                "burst_rest",          # dense burst then rest
-                "chord_rush",          # all-chord measure
-                "split_hands",         # left/right hand alternating patterns
+                "stream_random", "stream_jump", "jacks",
+                "trill_fast", "complex_stairs", "hand_stream",
+                "ln_stream", "burst_rest", "chord_rush", "split_hands",
             ]
             pattern_type = random.choice(pattern_types)
-            
-            # If LN disabled, skip LN pattern
+
             if pattern_type == "ln_stream" and not has_ln:
                 pattern_type = random.choice(["stream_random", "jacks", "complex_stairs"])
 
             if pattern_type == "ln_stream":
                 ln1 = random.randint(0, 1)
                 ln2 = random.randint(2, 3)
-                m_data[ln_lanes[ln1]][0] = random.choice(synths)
-                m_data[ln_lanes[ln1]][8] = random.choice(synths)
-                m_data[ln_lanes[ln2]][4] = random.choice(synths)
-                m_data[ln_lanes[ln2]][12] = random.choice(synths)
+                m_data[ln_lanes[ln1]][0]  = ns_idx(ln1, 0)
+                m_data[ln_lanes[ln1]][8]  = ns_idx(ln1, 8)
+                m_data[ln_lanes[ln2]][4]  = ns_idx(ln2, 4)
+                m_data[ln_lanes[ln2]][12] = ns_idx(ln2, 12)
                 avail = [lanes[i] for i in range(4) if i not in (ln1, ln2)]
                 for step in range(0, 16, 2):
                     if m_data[ln_lanes[ln1]][step] == "00" and m_data[ln_lanes[ln2]][step] == "00":
-                        m_data[random.choice(avail)][step] = random.choice(synths)
+                        l = random.choice(avail)
+                        m_data[l][step] = ns(l, step)
 
             elif pattern_type == "stream_random":
-                # True random: pick any lane per step, but weight AWAY from last 2
                 history = []
                 for step in range(16):
                     avail = list(range(4))
-                    # Remove last lane from candidates most of the time
                     if len(history) >= 1 and history[-1] in avail and random.random() < 0.7:
                         avail.remove(history[-1])
-                    # Also remove 2nd-to-last sometimes (prevent back-n-forth)
                     if len(history) >= 2 and history[-2] in avail and random.random() < 0.3:
                         avail.remove(history[-2])
                     chosen = random.choice(avail)
-                    m_data[lanes[chosen]][step] = random.choice(synths)
+                    m_data[lanes[chosen]][step] = ns_idx(chosen, step)
                     history.append(chosen)
 
             elif pattern_type == "stream_jump":
-                # 16th stream but every 4 steps add a chord
                 history = []
                 for step in range(16):
                     avail = list(range(4))
                     if history and history[-1] in avail and random.random() < 0.6:
                         avail.remove(history[-1])
                     chosen = random.choice(avail)
-                    m_data[lanes[chosen]][step] = random.choice(synths)
-                    if step % 4 == 0:  # Add chord partner
+                    m_data[lanes[chosen]][step] = ns_idx(chosen, step)
+                    if step % 4 == 0:
                         others = [i for i in range(4) if i != chosen]
-                        m_data[lanes[random.choice(others)]][step] = random.choice(synths)
+                        other = random.choice(others)
+                        m_data[lanes[other]][step] = ns_idx(other, step)
                     history.append(chosen)
 
             elif pattern_type == "jacks":
-                # 3-8 consecutive hits on same lane, fill rest randomly
                 jack_lane = random.randint(0, 3)
                 start = random.choice([0, 2, 4])
                 length = random.randint(3, 6)
                 for step in range(start, min(start + length, 16)):
-                    m_data[lanes[jack_lane]][step] = random.choice(synths)
-                # Fill some other steps
+                    m_data[lanes[jack_lane]][step] = ns_idx(jack_lane, step)
                 for step in range(16):
                     if m_data[lanes[jack_lane]][step] == "00" and random.random() < 0.3:
-                        others = [lanes[i] for i in range(4) if i != jack_lane]
-                        m_data[random.choice(others)][step] = random.choice(synths)
+                        others = [i for i in range(4) if i != jack_lane]
+                        other = random.choice(others)
+                        m_data[lanes[other]][step] = ns_idx(other, step)
 
             elif pattern_type == "trill_fast":
-                # super-fast 2-lane 16th trill, randomly pick the pair
                 pair = random.sample(range(4), 2)
                 for step in range(16):
-                    m_data[lanes[pair[step % 2]]][step] = random.choice(synths)
+                    idx = pair[step % 2]
+                    m_data[lanes[idx]][step] = ns_idx(idx, step)
 
             elif pattern_type == "complex_stairs":
-                # Generate 8 unique non-linear stair patterns
                 templates = [
-                    [0,2,1,3,0,2,1,3],
-                    [3,1,2,0,3,1,2,0],
-                    [0,3,1,2,3,0,2,1],
-                    [1,0,3,2,1,0,3,2],
-                    [2,3,0,1,2,3,0,1],
-                    [3,0,2,1,0,3,1,2],
-                    [1,3,0,2,3,1,0,2],
-                    [2,0,3,1,0,2,3,1],
+                    [0,2,1,3,0,2,1,3], [3,1,2,0,3,1,2,0],
+                    [0,3,1,2,3,0,2,1], [1,0,3,2,1,0,3,2],
+                    [2,3,0,1,2,3,0,1], [3,0,2,1,0,3,1,2],
+                    [1,3,0,2,3,1,0,2], [2,0,3,1,0,2,3,1],
                 ]
                 pts = random.choice(templates)
-                # Random start offset to further vary
                 offset = random.randint(0, 3)
                 for i in range(8):
                     lane_idx = (pts[i] + offset) % 4
                     step = i * 2
-                    m_data[lanes[lane_idx]][step] = random.choice(synths)
+                    m_data[lanes[lane_idx]][step] = ns_idx(lane_idx, step)
 
             elif pattern_type == "hand_stream":
-                # 8th-note chords on beat positions, 16th singles on off-positions
                 for step in range(16):
-                    if step % 4 == 0:  # On beat: 2-note chord
-                        chord = random.sample(lanes, 2)
-                        for c in chord: m_data[c][step] = random.choice(synths)
-                    elif step % 2 == 0:  # Off-beat 8th: single note
-                        m_data[random.choice(lanes)][step] = random.choice(synths)
-                    else:  # 16th: occasional single
+                    if step % 4 == 0:
+                        chord = random.sample(range(4), 2)
+                        for c in chord:
+                            m_data[lanes[c]][step] = ns_idx(c, step)
+                    elif step % 2 == 0:
+                        c = random.randint(0, 3)
+                        m_data[lanes[c]][step] = ns_idx(c, step)
+                    else:
                         if random.random() < 0.6:
-                            m_data[random.choice(lanes)][step] = random.choice(synths)
+                            c = random.randint(0, 3)
+                            m_data[lanes[c]][step] = ns_idx(c, step)
 
             elif pattern_type == "burst_rest":
-                # Dense burst of 6-10 notes, rest of measure empty
                 burst_len = random.randint(6, 10)
                 start = random.randint(0, max(0, 16 - burst_len))
-                end = min(start + burst_len, 16)  # clamp
+                end = min(start + burst_len, 16)
                 history = []
                 for step in range(start, end):
                     avail = list(range(4))
                     if history and history[-1] in avail and random.random() < 0.65:
                         avail.remove(history[-1])
                     chosen = random.choice(avail)
-                    m_data[lanes[chosen]][step] = random.choice(synths)
+                    m_data[lanes[chosen]][step] = ns_idx(chosen, step)
                     history.append(chosen)
 
             elif pattern_type == "chord_rush":
-                # Every other step throws 2-note chords
                 for step in range(0, 16, 2):
-                    chord = random.sample(lanes, random.choice([1, 2, 2]))
-                    for c in chord: m_data[c][step] = random.choice(synths)
+                    chord = random.sample(range(4), random.choice([1, 2, 2]))
+                    for c in chord:
+                        m_data[lanes[c]][step] = ns_idx(c, step)
 
             elif pattern_type == "split_hands":
-                # Left hand (lanes 0,1) alternates with right hand (lanes 2,3) each 8th note
-                left = [lanes[0], lanes[1]]
-                right = [lanes[2], lanes[3]]
                 for step in range(0, 16, 2):
-                    hand = left if (step // 2) % 2 == 0 else right
-                    # Optionally double up
+                    if (step // 2) % 2 == 0:
+                        hand = [0, 1]
+                    else:
+                        hand = [2, 3]
                     picks = random.sample(hand, random.choice([1, 1, 2]))
-                    for l in picks: m_data[l][step] = random.choice(synths)
-
+                    for idx in picks:
+                        m_data[lanes[idx]][step] = ns_idx(idx, step)
 
         # Write lines to chart
         all_channels = ["01", "08"] + lanes + ln_lanes
@@ -440,8 +581,8 @@ def generate_random_course(duration_ms, out_path, template_dir, difficulty="BEGI
             ch_data_str = "".join(m_data[ch])
             if any(x != "00" for x in m_data[ch]):
                 chart_data += f"#{measure_str}{ch}:{ch_data_str}\n"
-    
+
     with open(out_path, 'w', encoding='utf-8') as f:
         f.write(header + chart_data)
-    
+
     return out_path, desc_str


### PR DESCRIPTION
## Summary
- Replace single monotone `key_tap.wav` with ~36 synthesized instruments across A minor pentatonic (4 octaves)
- New wave types: sub_bass (saw + tanh distortion), synth_lead (detuned supersaw), pluck, chord_stab (triads), fx_riser, fx_impact, hihat_open
- Musical note assignment: lane → register mapping (bass/lead/arp/FX), beat-position awareness, phrase system with root rotation every 4 bars and style switching (trap/future_bass/arp) every 8 bars
- Enhanced BGM: hi-hat 8th notes, open hat accents, riser FX on phrase transitions
- Includes volume fix from #3

## Test plan
- [ ] Play course mode at each difficulty (BEGINNER through ORDEAL)
- [ ] Confirm distinct sounds per lane and varying sounds within the same lane
- [ ] Verify BPM changes (SV) and long notes (LN) still function correctly
- [ ] Check that audio generation completes quickly (no noticeable delay)

🤖 Generated with [Claude Code](https://claude.com/claude-code)